### PR TITLE
[ignore] run govet during lint checks

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,6 +16,7 @@ linters:
     - gochecksumtype
     - gosec
     - gosmopolitan
+    - govet
     - loggercheck
     - makezero
     - musttag

--- a/.tekton/namespace-lister-pull-request.yaml
+++ b/.tekton/namespace-lister-pull-request.yaml
@@ -14,7 +14,7 @@ metadata:
     appstudio.openshift.io/component: namespace-lister
     pipelines.appstudio.openshift.io/type: build
   name: namespace-lister-on-pull-request
-  namespace: konflux-tenant-ops-tenant
+  namespace: rh-ee-filario-2-tenant
 spec:
   params:
   - name: git-url

--- a/.tekton/namespace-lister-push.yaml
+++ b/.tekton/namespace-lister-push.yaml
@@ -13,7 +13,7 @@ metadata:
     appstudio.openshift.io/component: namespace-lister
     pipelines.appstudio.openshift.io/type: build
   name: namespace-lister-on-push
-  namespace: konflux-tenant-ops-tenant
+  namespace: rh-ee-filario-2-tenant
 spec:
   params:
   - name: git-url


### PR DESCRIPTION
One less thing to special-case in our ci definitions.